### PR TITLE
Add instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ cargo build --release
 cargo run --release
 ```
 
+On Linux it might be required to install the `fontconfig-devel` library.
+
 ### Running
 ```bash
 # From the project directory


### PR DESCRIPTION
On Fedora the `fontconfig-devel` library is not installed by default.  If it is not installed the program will not compile.

